### PR TITLE
fix: many assignee for topic issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/topic-request.md
+++ b/.github/ISSUE_TEMPLATE/topic-request.md
@@ -3,7 +3,10 @@ name: Topic Request for Bitdevs
 about: Propositions de thématique Bitdevs.
 title: "topic: [Topic title]"
 labels: topics
-assignees: ['heyolaniran','mehounme','block67']
+assignees:
+    - heyolaniran
+    - AlphonseMehounme
+    - block67
 ---
 
 ## Topic details


### PR DESCRIPTION
When issue was created it is automatically assigned to the last topic maintainers instead of randomly tag someone or tag them all.